### PR TITLE
feature parity with CanvasScroll

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,10 @@ To install, browse for it in the module browser, or [directly copy the manifest 
 ## Disable zoom rounding
 - Disables default Foundry behavior, which rounds zoom to the nearest 1%. Will make zooming smoother, especially for touchpad users.
  
-## Touchpad Scrolling (also useful for Magic Mouse)
+## Touchpad/Scrollwheel Mode
+(also useful for Magic Mouse)
+
+While Checked, the following are true:
 - Vertical mouse scroll will now pan up and down (instead of zooming)
 - Horizontal mouse scroll will now pan left and right
 - Shift+scroll will now pan left and right
@@ -23,6 +26,9 @@ To install, browse for it in the module browser, or [directly copy the manifest 
 - Alt+scroll will now precisely rotate a token (like previous ctrl+scroll)
 - Alt+Shift+scroll will now rotate a token quickly (like previous shift+scroll)
 
+## Pan speed multiplier
+- Only used in touchpad mode. Multiplies pan speed. Defaults to 1, which should be close to the pan speed when right-click-dragging the canvas.
+
 ## Zoom speed multiplier
 - Useful if your zoom is too sensitive, or not sensitive enough. A value of 0.1, 10, or 20 might work for you.
 
@@ -31,7 +37,7 @@ To install, browse for it in the module browser, or [directly copy the manifest 
 Thanks, mrkwnzl#7407, for the touchpad support!
 
 # [Canvas Scroll](https://github.com/ElfFriend-DnD/foundryvtt-canvasScroll)
-Apparently this module was developed at the same time this one was, and can do something very similar. Oops!
+Apparently this module was developed at the same time this one was, and can do something very similar. @akrigline helped merge his features into this module.
 
 # [Cursor Zoom](https://github.com/itamarcu/CursorZoom)
 My old foundry module, that only had the "Zoom around cursor" feature, and did not allow configuring it in the settings for each player.

--- a/Readme.md
+++ b/Readme.md
@@ -16,10 +16,12 @@ To install, browse for it in the module browser, or [directly copy the manifest 
 ## Touchpad Scrolling (also useful for Magic Mouse)
 - Vertical mouse scroll will now pan up and down (instead of zooming)
 - Horizontal mouse scroll will now pan left and right
-- Panning with two fingers on a touchpad should use these two and should be nicer
+- Shift+scroll will now pan left and right
+- Panning with two fingers on a touchpad should pan
 - Ctrl+scroll will now zoom in and out (like previous vertical scroll) (instead of precisely rotating a token)
-- Pinching with two fingers on a touchpad should use this and should be nice
-- Shift+Ctrl+scroll will now precisely rotate a token (like previous ctrl+scroll)
+- Pinching with two fingers on a touchpad should zoom
+- Alt+scroll will now precisely rotate a token (like previous ctrl+scroll)
+- Alt+Shift+scroll will now rotate a token quickly (like previous shift+scroll)
 
 ## Zoom speed multiplier
 - Useful if your zoom is too sensitive, or not sensitive enough. A value of 0.1, 10, or 20 might work for you.

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "name": "zoom-pan-options",
   "title": "Zoom/Pan Options",
-  "description": "Adds cursor-based zoom, touchpad zoom/pan support, and other options.",
+  "description": "Adds cursor-based zoom, touchpad/scrollwheel zoom/pan support, and other options.",
   "author": "shem",
   "version": "1.1.0",
   "minimumCoreVersion": "0.6.0",

--- a/module.json
+++ b/module.json
@@ -3,10 +3,10 @@
   "title": "Zoom/Pan Options",
   "description": "Adds cursor-based zoom, touchpad zoom/pan support, and other options.",
   "author": "shem",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "0.6.6",
-  "scripts": [
+  "esmodules": [
     "zoom-pan-options.js"
   ],
   "url": "https://github.com/itamarcu/ZoomPanOptions",

--- a/zoom-pan-options.js
+++ b/zoom-pan-options.js
@@ -1,58 +1,71 @@
-console.log("Zoom/Pan Options is setting up...");
-
+console.log('zoom-pan-options |', 'Setting up...');
 
 function getSetting(settingName) {
-  return game.settings.get("zoom-pan-options", settingName)
+  return game.settings.get('zoom-pan-options', settingName);
 }
 
 function _onWheel_Override(event) {
-  const touchpad = getSetting("touchpad-scroll")
-  if (event.deltaY === 0 && !touchpad)
-    return
+  const touchpad = getSetting('touchpad-scroll');
 
   // Prevent zooming the entire browser window
-  if (event.ctrlKey) event.preventDefault();
+  if (event.ctrlKey) {
+    event.preventDefault();
+  }
 
   // Handle wheel events for the canvas if it is ready and if it is our hover target
   let hover = document.elementFromPoint(event.clientX, event.clientY);
-  if (canvas && canvas.ready && hover && (hover.id === "board")) {
-    event.preventDefault();
-    let layer = canvas.activeLayer;
-    let isCtrl = event.ctrlKey || event.metaKey, isShift = event.shiftKey;
 
-    // Case 1 - rotate tokens or tiles
-    if (layer instanceof PlaceablesLayer && (isShift || (isCtrl && !touchpad))) {
-      if (touchpad && isShift && isCtrl) {
-        // Shift+Ctrl on touchpad will do what Ctrl+scroll used to do (rotate in 15° increments)
-        layer._onMouseWheel({
-          deltaY: event.deltaY, // only the sign matters, actually
-          shiftKey: false,
-          ctrlKey: event.ctrlKey,
-          metaKey: event.metaKey,
-        })
-      } else {
-        layer._onMouseWheel(event)
-      }
+  if (canvas && canvas.ready && hover && hover.id === 'board') {
+    event.preventDefault();
+    const layer = canvas.activeLayer;
+    const isOsx = window.navigator.platform === 'MacIntel';
+
+    /* These can become options easily */
+    const rotateKey = event.altKey;
+    const directionModifierKey = event.shiftKey; // changes pan direction
+    const rotationModifierKey = event.shiftKey; // changes rotation amount
+    const zoomKey = event.ctrlKey || event.metaKey;
+
+    // Case 1 - handle rotation of objects
+    // default to Alt for rotation as we are moving Shift to horizontal scroll and Ctrl is reserved for pinch zooming (OSX)
+    if (layer instanceof PlaceablesLayer && (rotateKey || (rotationModifierKey && !touchpad))) {
+      // return so we don't proceed
+      return layer._onMouseWheel({
+        ctrlKey: rotateKey, // shim alt where foundry expects ctrl for rotation
+        deltaY: event.wheelDelta, // only the sign matters, use wheelDelta instead of relying on deltaY
+        metaKey: event.metaKey,
+        shiftKey: modifierKey,
+      });
     }
+
     // Case 2 - zoom the canvas (touchpad pinch, or normal scroll)
-    else if (isCtrl || !touchpad) zoom(event)
-    // Case 3 - pan the canvas (touchpad scroll)
-    else panWithTouchpad(event);
+    if (zoomKey || !touchpad) {
+      return zoom(event);
+    }
+
+    // Cast 3 - pan the canvas but flip X and Y (touchpad scroll + SHIFT and not OSX)
+    if (touchpad && !isOsx && directionModifierKey) {
+      return panWithTouchpad({
+        deltaX: event.deltaY,
+        deltaY: event.deltaX,
+      });
+    }
+
+    // Case 4 - pan the canvas (touchpad scroll)
+    panWithTouchpad(event);
   }
 }
 
-function _constrainView_Override({x, y, scale}) {
+function _constrainView_Override({ x, y, scale }) {
   const d = canvas.dimensions;
 
   // Constrain the maximum zoom level
-  if (Number.isNumeric(scale) && (scale !== this.stage.scale.x)) {
+  if (Number.isNumeric(scale) && scale !== this.stage.scale.x) {
     const max = CONFIG.Canvas.maxZoom;
     const ratio = Math.max(d.width / window.innerWidth, d.height / window.innerHeight, max);
     // override changes are just for this part:
-    if (getSetting("disable-zoom-rounding"))
-      scale = Math.clamped(scale, 1 / ratio, max);
-    else
-      scale = Math.round(Math.clamped(scale, 1 / ratio, max) * 100) / 100;
+    if (getSetting('disable-zoom-rounding')) scale = Math.clamped(scale, 1 / ratio, max);
+    else scale = Math.round(Math.clamped(scale, 1 / ratio, max) * 100) / 100;
   } else {
     scale = this.stage.scale.x;
   }
@@ -68,88 +81,97 @@ function _constrainView_Override({x, y, scale}) {
   } else y = this.stage.pivot.y;
 
   // Return the constrained view dimensions
-  return {x, y, scale};
+  return { x, y, scale };
 }
 
 /**
  * Will zoom around cursor, and based on delta.
  */
 function zoom(event) {
-  const multiplier = getSetting("zoom-speed-multiplier")
-  let dz = (-event.deltaY) * 0.0005 * multiplier + 1
-  if (!getSetting("zoom-around-cursor")) {
-    canvas.pan({scale: dz * canvas.stage.scale.x});
+  const multiplier = getSetting('zoom-speed-multiplier');
+  let dz = -event.deltaY * 0.0005 * multiplier + 1;
+
+  if (!getSetting('zoom-around-cursor')) {
+    canvas.pan({ scale: dz * canvas.stage.scale.x });
     return;
   }
+
   const scale = dz * canvas.stage.scale.x;
   const d = canvas.dimensions;
   const max = CONFIG.Canvas.maxZoom;
   const min = 1 / Math.max(d.width / window.innerWidth, d.height / window.innerHeight, max);
+
   if (scale > max || scale < min) {
-    canvas.pan({scale: scale > max ? max : min});
-    console.log(`Zoom/Pan Options | scale limit reached (${scale}).`)
-    return
+    canvas.pan({ scale: scale > max ? max : min });
+    console.log('zoom-pan-options |', `scale limit reached (${scale}).`);
+    return;
   }
+
   // Acquire the cursor position transformed to Canvas coordinates
   const t = canvas.stage.worldTransform;
   const dx = ((-t.tx + event.clientX) / canvas.stage.scale.x - canvas.stage.pivot.x) * (dz - 1);
   const dy = ((-t.ty + event.clientY) / canvas.stage.scale.y - canvas.stage.pivot.y) * (dz - 1);
   const x = canvas.stage.pivot.x + dx;
   const y = canvas.stage.pivot.y + dy;
-  canvas.pan({x, y, scale});
+  canvas.pan({ x, y, scale });
 }
 
 function panWithTouchpad(event) {
-  const multiplier = 1 / canvas.stage.scale.x * getSetting('pan-speed-multiplier')
-  const x = canvas.stage.pivot.x + event.deltaX * multiplier
-  const y = canvas.stage.pivot.y + event.deltaY * multiplier
-  canvas.pan({x, y})
+  const multiplier = (1 / canvas.stage.scale.x) * getSetting('pan-speed-multiplier');
+  const x = canvas.stage.pivot.x + event.deltaX * multiplier;
+  const y = canvas.stage.pivot.y + event.deltaY * multiplier;
+  canvas.pan({ x, y });
 }
 
-Hooks.on("init", function () {
-  game.settings.register("zoom-pan-options", "zoom-around-cursor", {
-    name: "Zoom around cursor",
-    hint: "Center zooming around cursor. Does not apply to zooming with pageup or pagedown.",
-    scope: "client",
+Hooks.on('init', function () {
+  game.settings.register('zoom-pan-options', 'zoom-around-cursor', {
+    name: 'Zoom around cursor',
+    hint: 'Center zooming around cursor. Does not apply to zooming with pageup or pagedown.',
+    scope: 'client',
     config: true,
     default: true,
-    type: Boolean
-  })
-  game.settings.register("zoom-pan-options", "touchpad-scroll", {
-    name: "Zoom by pinching, pan by dragging (Touchpad mode)",
-    hint: "Pan with two-finger drag (or vertical/horizontal scroll)." +
-      " Zoom with two-finger pinch (or Ctrl+scroll)." +
-      " Precisely rotate a token with Ctrl+Shift+scroll.",
-    scope: "client",
+    type: Boolean,
+  });
+  game.settings.register('zoom-pan-options', 'touchpad-scroll', {
+    name: 'Touchpad/Scrollwheel Mode',
+    hint:
+      'Pan with two-finger drag (or scroll wheel, Shift + scroll for Horizontal). Zoom with two-finger pinch (or Ctrl + scroll).',
+    scope: 'client',
     config: true,
     default: false,
-    type: Boolean
-  })
-  game.settings.register("zoom-pan-options", "disable-zoom-rounding", {
-    name: "Disable zoom rounding",
-    hint: "Disables default Foundry behavior, which rounds zoom to the nearest 1%. Will make zooming smoother, especially for touchpad users.",
-    scope: "client",
+    type: Boolean,
+  });
+  game.settings.register('zoom-pan-options', 'disable-zoom-rounding', {
+    name: 'Disable zoom rounding',
+    hint:
+      'Disables default Foundry behavior, which rounds zoom to the nearest 1%. Will make zooming smoother, especially for touchpad users.',
+    scope: 'client',
     config: true,
     default: true,
-    type: Boolean
-  })
-  game.settings.register("zoom-pan-options", "zoom-speed-multiplier", {
-    name: "Zoom speed",
-    hint: "Multiplies zoom speed, affecting scaling speed. Defaults to 1 (5% zoom per mouse tick). 0.1 or 10 might be better for some touchpads.",
-    scope: "client",
+    type: Boolean,
+  });
+  game.settings.register('zoom-pan-options', 'zoom-speed-multiplier', {
+    name: 'Zoom speed',
+    hint:
+      'Multiplies zoom speed, affecting scaling speed. Defaults to 1 (5% zoom per mouse tick). 0.1 or 10 might be better for some touchpads.',
+    scope: 'client',
     config: true,
     default: 1,
     type: Number,
-  })
-  game.settings.register("zoom-pan-options", "pan-speed-multiplier", {
-    name: "Pan speed",
-    hint: "Multiplies pan speed, for touchpads. Defaults to 1, which should be close to the pan speed when right-click-dragging the canvas.",
-    scope: "client",
+  });
+  game.settings.register('zoom-pan-options', 'pan-speed-multiplier', {
+    name: 'Pan speed',
+    hint:
+      'Only used in touchpad mode. Multiplies pan speed. Defaults to 1, which should be close to the pan speed when right-click-dragging the canvas.',
+    scope: 'client',
     config: true,
     default: 1,
     type: Number,
-  })
+  });
+
   KeyboardManager.prototype._onWheel = _onWheel_Override;
-  Canvas.prototype._constrainView = _constrainView_Override
-  console.log("Zoom/Pan Options is done setting up!");
+
+  Canvas.prototype._constrainView = _constrainView_Override;
+
+  console.log('zoom-pan-options |', 'Done setting up!');
 });

--- a/zoom-pan-options.js
+++ b/zoom-pan-options.js
@@ -34,7 +34,7 @@ function _onWheel_Override(event) {
         ctrlKey: rotateKey, // shim alt where foundry expects ctrl for rotation
         deltaY: event.wheelDelta, // only the sign matters, use wheelDelta instead of relying on deltaY
         metaKey: event.metaKey,
-        shiftKey: modifierKey,
+        shiftKey: rotationModifierKey,
       });
     }
 

--- a/zoom-pan-options.js
+++ b/zoom-pan-options.js
@@ -4,6 +4,7 @@ function getSetting(settingName) {
   return game.settings.get('zoom-pan-options', settingName);
 }
 
+// TODO Disable Alt key if touchmode is false.
 function _onWheel_Override(event) {
   const touchpad = getSetting('touchpad-scroll');
 
@@ -21,7 +22,7 @@ function _onWheel_Override(event) {
     const isOsx = window.navigator.platform === 'MacIntel';
 
     /* These can become options easily */
-    const rotateKey = event.altKey;
+    const rotateKey = touchpad ? event.altKey : event.ctrlKey || event.metaKey ;
     const directionModifierKey = event.shiftKey; // changes pan direction
     const rotationModifierKey = event.shiftKey; // changes rotation amount
     const zoomKey = event.ctrlKey || event.metaKey;


### PR DESCRIPTION
Resolves #2. Lays some groundwork for #1 if that is desired in the future.

A couple tweaks to the behavior to enable horizontal panning via mouse wheel, which would let this merge completely with the CanvasScroll module I was developing.

- Formatted JS with Prettier (sorry if that's not the formatter you use, let me know what would work better)
- Made Shift + Scroll pan horizontally in touchpad mode
- Laid groundwork for allowing users to set their own keys desired
- Changed default rotation key to Alt in touchpad mode, which now behaves how Ctrl behaves in non-touchpad mode
  - Turns out that `event.ctrlKey` is how OSX handles pinch zooming

Tested on Windows 10 Foundry Client (Mouse + Keyboard) and OSX Chrome (Macbook Pro 2018 Touchpad, Mouse + Keyboard)