### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         files: 'module.json'
       env:
         version: ${{github.event.release.tag_name}}
-        manifest: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
+        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
         download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
     # Create a zip file with all files required by the module to add to the release


### PR DESCRIPTION
I recently realized that I set this up super wrong, and that the current setup has not been allowing the Foundry UI to update the module automatically.

`manifest` in `module.json` should always point at `latest`, but `download` should point at the specific release.

This change fixes that setup.