### PR TITLE
Auto detect touchpads

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "title": "Zoom/Pan Options",
   "description": "Adds cursor-based zoom, touchpad/scrollwheel zoom/pan support, and other options.",
   "author": "shem",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "0.8.5",
   "esmodules": [

--- a/scripts/zoom-pan-options.js
+++ b/scripts/zoom-pan-options.js
@@ -21,10 +21,26 @@ function checkRotationRateLimit (layer) {
  * (note: return value is meaningless here)
  */
 function _onWheel_Override (event) {
-  const mode = getSetting('pan-zoom-mode')
+  let mode = getSetting('pan-zoom-mode')
   const shift = event.shiftKey
   const alt = event.altKey
   const ctrlOrMeta = event.ctrlKey || event.metaKey  // meta key (cmd on mac, winkey in windows) will behave like ctrl
+
+  // Switch to touchpad if touchpad is detected
+  if (mode === 'Default') {
+    if (event.deltaX !== 0 && event.deltaY !== 0) {
+      // When moving on both X & Y axis, it can't be a mouse scroll
+      mode = 'Touchpad'
+    } else {
+      const deltaX = String(event.deltaX).split('.');
+      const deltaY = String(event.deltaY).split('.');
+      // If there is a decimal point whith 2 or more numbers after the point 
+      // That means there is precise movement => touchpad
+      if ((deltaX.length > 1 && deltaX[1].length > 1) || deltaY.length > 1 && deltaY[1].length > 1) {
+        mode = 'Touchpad'
+      }
+    }
+  }
 
   // Prevent zooming the entire browser window
   if (ctrlOrMeta) {


### PR DESCRIPTION
Hi,

I was looking into auto detecting mouse scrolls vs touchpad scrolls.
Unfortunately it does not seem to be standardized, though though testing with my own laptop (a nice big sample size of 1...) this seems to work well enough.

Not sure if you want to add a new separate auto detect mode next to the default. My idea is that the default should work the best out of the box => default = auto detect.